### PR TITLE
Add local LLM and support for running in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/Dockerfile
+/Meta-Llama-3-8B-Instruct.Q6_K.gguf

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 /Dockerfile
-/Meta-Llama-3-8B-Instruct.Q6_K.gguf
+/*.gguf

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+/Meta-Llama-3-8B-Instruct.Q6_K.gguf

--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-/Meta-Llama-3-8B-Instruct.Q6_K.gguf
+/*.gguf

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN pip install -r requirements.txt
 COPY . .
 
 EXPOSE 5000
+ENV LOCAL_LLM=1
 CMD ["gunicorn", "-b", "0.0.0.0:5000", "-w", "4", "-k", "gevent", "--worker-tmp-dir", "/dev/shm", "--timeout", "120", "ranking_server:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:12
+
+RUN apt-get update && apt-get install -y python3.11 python3.11-dev python3.11-venv python3-pip curl && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /app
+WORKDIR /app
+
+# TODO(kochman): don't require this to be present locally
+# COPY Meta-Llama-3-8B-Instruct.Q6_K.gguf .
+RUN curl --location https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct.Q6_K.gguf?download=true -o Meta-Llama-3-8B-Instruct.Q6_K.gguf
+
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+ENV VIRTUAL_ENV=/venv
+
+COPY . .
+RUN pip install -r requirements.txt 
+
+EXPOSE 5000
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "-w", "4", "-k", "gevent", "--worker-tmp-dir", "/dev/shm", "--timeout", "120", "ranking_server:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,16 @@ RUN apt-get update && apt-get install -y python3.11 python3.11-dev python3.11-ve
 RUN mkdir /app
 WORKDIR /app
 
-# TODO(kochman): don't require this to be present locally
-# COPY Meta-Llama-3-8B-Instruct.Q6_K.gguf .
-RUN curl --location https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct.Q6_K.gguf?download=true -o Meta-Llama-3-8B-Instruct.Q6_K.gguf
+RUN curl --location https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct.Q4_K_S.gguf?download=true -o Meta-Llama-3-8B-Instruct.Q4_K_S.gguf
 
 RUN python3 -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 ENV VIRTUAL_ENV=/venv
 
-COPY . .
+COPY requirements.txt .
 RUN pip install -r requirements.txt 
+
+COPY . .
 
 EXPOSE 5000
 CMD ["gunicorn", "-b", "0.0.0.0:5000", "-w", "4", "-k", "gevent", "--worker-tmp-dir", "/dev/shm", "--timeout", "120", "ranking_server:app"]

--- a/ranking_server.py
+++ b/ranking_server.py
@@ -4,7 +4,7 @@ import os
 # from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 from flask_cors import CORS
-from llama_cpp import Llama
+from llama_cpp import Llama, LlamaRAMCache
 
 
 try:
@@ -14,6 +14,7 @@ except:
     exit(1)
 
 llm = Llama(model_path="Meta-Llama-3-8B-Instruct.Q6_K.gguf")
+llm.set_cache(LlamaRAMCache())
 app = Flask(__name__)
 CORS(app)
 

--- a/ranking_server.py
+++ b/ranking_server.py
@@ -4,18 +4,31 @@ import os
 # from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 from flask_cors import CORS
+from openai import OpenAI
 from llama_cpp import Llama, LlamaRAMCache
 
 
-model_name = "Meta-Llama-3-8B-Instruct.Q4_K_S.gguf"
-try:
-    os.stat(model_name)
-except:
-    print(f"Please download https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/blob/main/{model_name} and place it in the current directory.")
-    exit(1)
+USE_LOCAL_LLM = os.getenv("LOCAL_LLM") == "1"
 
-llm = Llama(model_path=model_name)
-llm.set_cache(LlamaRAMCache())
+if USE_LOCAL_LLM:
+    model_name = "Meta-Llama-3-8B-Instruct.Q4_K_S.gguf"
+    try:
+        os.stat(model_name)
+    except:
+        print(f"Please download https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/blob/main/{model_name} and place it in the current directory.")
+        exit(1)
+
+    llm = Llama(model_path=model_name)
+    llm.set_cache(LlamaRAMCache())
+else:
+    # Load environment variables
+    file = open("/etc/secrets/api_key.txt", "r")
+    API_TOKEN = file.read()
+    file.close()
+
+    # load_dotenv()  # if a .env file exists, load environment variables from it
+    client = OpenAI(api_key=API_TOKEN)
+
 app = Flask(__name__)
 CORS(app)
 
@@ -37,7 +50,46 @@ Prior evidence to suggest this: My friends and family who became jaded since the
 
 We will start with Palestine/Israelfocus and broaden it if we do notsee the variables shift.'''
 
-def generate_rankings(items):
+def generate_rankings_openai(items):
+    prompt = ""
+    for i, item in enumerate(items):
+        prompt += f"ITEM: {i}:\n{item['text']}\n\n"
+
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {
+                "role": "system",
+                "content": 'You are a helpful assistant that processes text and returns results in JSON format. Reorder the items you are given in terms of their positivity, with the most positive item first, and include your reasoning. Give me a JSON array in the following format: [ {"item_idx": int, "reason": str} ]. Kindly use the following as a guide for categorization of text concerning Palestine and Israel: A one-sided, Palestinian(s) view that only mentions Israel govt and/or people in a negative light should be considered as negative. A one-sided, Palestinian(s) view with no mention of Israeli govt and/or people should be considered as neutral. A one-sided, Israeli(s) view with no mention of Palestinian govt and/or people should be considered as neutral. A one-sided, Israeli(s) view which only mentions Palestinian govt and/or people in a negative light should be considered as negative. Palestinians and Israelis focusing on overcoming division should be considered as positive',
+            },
+            {
+                "role": "user",
+                "content": "ITEM 0:\nI love you.\n\nITEM 1:\nI hate you.\n\nITEM 2:\nI am indifferent to you.\nITEM 3:\nI like soup\n\n",
+            },
+            {
+                "role": "assistant",
+                "content": '[ {"item_idx": 0, "reason": "The statement is very positive."}, {"item_idx": 3, "reason": "The statement is somewhat positive."}, {"item_idx": 2, "reason": "The statement is neutral."}, {"item_idx": 1, "reason": "The statement is negative."} ]',
+            },
+            {
+                "role": "user",
+                "content": prompt,
+            },
+        ],
+    )
+
+    json_results = response.choices[0].message.content.strip()
+
+    # From the docs
+    # Warning: Be cautious when parsing JSON data from untrusted sources. A malicious JSON string may cause the decoder to
+    # consume considerable CPU and memory resources. Limiting the size of data to be parsed is recommended.
+    results = json.loads(json_results)
+
+    indices = [item["item_idx"] for item in results]
+    rankings = [items[i]["id"] for i in indices]
+
+    return rankings
+
+def generate_rankings_local_llm(items):
     prompt = ""
     for i, item in enumerate(items):
         prompt += f"ITEM: {i}:\n{item['text']}\n\n"
@@ -104,7 +156,10 @@ def rank_items():
     
     items = post_data.get("items")
 
-    ranked_ids = generate_rankings(items)
+    if USE_LOCAL_LLM:
+        ranked_ids = generate_rankings_local_llm(items)
+    else:
+        ranked_ids = generate_rankings_openai(items)
 
     # Add new posts (not part of the candidate set) to the top of the result
     # ranked_ids = [new_post["id"] for new_post in NEW_POSTS] + ranked_ids

--- a/ranking_server.py
+++ b/ranking_server.py
@@ -7,13 +7,14 @@ from flask_cors import CORS
 from llama_cpp import Llama, LlamaRAMCache
 
 
+model_name = "Meta-Llama-3-8B-Instruct.Q4_K_S.gguf"
 try:
-    os.stat("Meta-Llama-3-8B-Instruct.Q6_K.gguf")
+    os.stat(model_name)
 except:
-    print("Please download https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/blob/main/Meta-Llama-3-8B-Instruct.Q6_K.gguf and place it in the current directory.")
+    print(f"Please download https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/blob/main/{model_name} and place it in the current directory.")
     exit(1)
 
-llm = Llama(model_path="Meta-Llama-3-8B-Instruct.Q6_K.gguf")
+llm = Llama(model_path=model_name)
 llm.set_cache(LlamaRAMCache())
 app = Flask(__name__)
 CORS(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests
-openai
 flask
 flask_cors
 pytest
 gunicorn
+llama-cpp-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ flask
 flask_cors
 pytest
 gunicorn
+gevent
 llama-cpp-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+openai
 flask
 flask_cors
 pytest


### PR DESCRIPTION
To start removing the dependency on OpenAI, this change adds support for generating LLM completions locally. This uses a quantized version of Meta's Llama 3 model via llama.cpp: https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF We can swap other models in very easily. I started with Llama 3 because it's new and currently doing well on the performance leaderboards.

To use this local LLM functionality, set an environment variable `LOCAL_LLM=1`. Note that it is currently very slow and it's only running on CPU—O(20 seconds) for a request to rank three items with one sentence of text each on my M2 MacBook Air! It also needs about eight gigabytes of memory. For these reasons I left the OpenAI completions as the default for now.

Additionally, I added a Dockerfile to build an image for easily running the server with local LLM. It pulls down the quantized GGUF file as a layer so that we don't need to do it at runtime. To use it:
1. `docker build -t unityfeed .`
2. `docker run -p5000:5000 -i unityfeed`
3. The server is now running on http://localhost:5000

I also spun it up at https://unityfeed.kochman.org via Docker.